### PR TITLE
imp: use memory file instead of job ID as the resume CLI arg

### DIFF
--- a/src/slfl/_cli.py
+++ b/src/slfl/_cli.py
@@ -12,13 +12,13 @@ def main():
         "tasks_file", type=Path, help="Path to .py file with tasks. Should be relative."
     )
     parser.add_argument(
-        "-j",
-        "--job_id",
-        type=str,
-        help="Job ID to resume. If not passed, a new job will be started.",
+        "-m",
+        "--memory_file",
+        type=Path,
+        help="Memory file to resume a job. If not passed, a new job will be started and a new memory file will be created.",
     )
     args = parser.parse_args()
 
-    exec_all(tasks_file=args.tasks_file, job_id=args.job_id)
+    exec_all(tasks_file=args.tasks_file, memory_file=args.memory_file)
 
     return 0

--- a/src/slfl/_dsl.py
+++ b/src/slfl/_dsl.py
@@ -78,31 +78,34 @@ def load_module_file(file_path: Path) -> ModuleType:
     return module
 
 
-def resolve_job_id(tasks_file: Path, memory_dir: Path, job_id: JobID | None) -> JobID:
-    if job_id is not None:
-        LOG.info("Resuming job %s", job_id)
+def resolve_job_id(
+    tasks_file: Path, memory_dir: Path, memory_file: Path | None
+) -> JobID:
+    if memory_file is not None:
+        job_id = memory_file.stem
+        LOG.info("Resuming job %s", memory_file)
         return job_id
     else:
-        resolved_job_id = gen_job_id(tasks_file, memory_dir=memory_dir)
-        LOG.info("Starting a new job %s", resolved_job_id)
-        return resolved_job_id
+        job_id = gen_job_id(tasks_file, memory_dir=memory_dir)
+        LOG.info("Starting a new job %s", job_id)
+        return job_id
 
 
-def exec_all(tasks_file: Path, job_id: JobID | None):
+def exec_all(tasks_file: Path, memory_file: Path | None):
     module = load_module_file(tasks_file)
     tasks = find_tasks_in_module(module)
 
     memory_dir = get_memory_dir()
 
-    resolved_job_id = resolve_job_id(
-        tasks_file=tasks_file, memory_dir=memory_dir, job_id=job_id
+    job_id = resolve_job_id(
+        tasks_file=tasks_file, memory_dir=memory_dir, memory_file=memory_file
     )
-    memory = YamlMemory.for_job(dir_path=memory_dir, job_id=resolved_job_id)
+    memory = YamlMemory.for_job(dir_path=memory_dir, job_id=job_id)
 
     runner = Runner(tasks=tasks, memory=memory)
     stats = runner.stats
     if stats.job_finished:
-        LOG.info("No more tasks to run! Job %s is finished.", resolved_job_id)
+        LOG.info("No more tasks to run! Job %s is finished.", job_id)
     else:
         LOG.info("Task %s/%s", stats.n_finished + 1, stats.n_total)
 

--- a/src/slfl/_dsl.py
+++ b/src/slfl/_dsl.py
@@ -71,9 +71,15 @@ def _prepend_to_path(sys_path: list[str], addition: str):
         sys_path[:] = orig_path
 
 
+def load_module_file(file_path: Path) -> ModuleType:
+    with _prepend_to_path(sys.path, addition=str(file_path.parent)):
+        module = importlib.import_module(file_path.stem, None)
+
+    return module
+
+
 def exec_all(tasks_file: Path, job_id: JobID | None):
-    with _prepend_to_path(sys.path, addition=str(tasks_file.parent)):
-        module = importlib.import_module(tasks_file.stem, None)
+    module = load_module_file(tasks_file)
     tasks = find_tasks_in_module(module)
 
     memory_dir = get_memory_dir()

--- a/src/slfl/_dsl.py
+++ b/src/slfl/_dsl.py
@@ -83,7 +83,7 @@ def resolve_job_id(
 ) -> JobID:
     if memory_file is not None:
         job_id = memory_file.stem
-        LOG.info("Resuming job %s", memory_file)
+        LOG.info("Resuming job %s", job_id)
         return job_id
     else:
         job_id = gen_job_id(tasks_file, memory_dir=memory_dir)

--- a/tests/unit/dsl/test_dsl.py
+++ b/tests/unit/dsl/test_dsl.py
@@ -1,14 +1,18 @@
+import logging
 import shutil
 import sys
 from pathlib import Path
-from pytest import MonkeyPatch, fixture
+
 from freezegun import freeze_time
+from pytest import LogCaptureFixture, MonkeyPatch, fixture
 from slfl._dsl import (
     find_tasks_in_module,
     get_memory_dir,
     gen_job_id,
     load_module_file,
+    resolve_job_id,
 )
+
 from ...example_proj.sample import tasks as sample_tasks
 
 
@@ -30,6 +34,47 @@ class TestLoadModuleFile:
         assert module is not None
         assert "amount_transfered_to_main" in dir(module)
         assert sys.path == starting_sys_path, "Shouldn't alter global sys.path"
+
+
+class TestResolveJobID:
+    @staticmethod
+    def test_id_not_passed(caplog: LogCaptureFixture):
+        # Given
+        tasks_file = Path("tasks/sample.py")
+        memory_dir = Path("memory")
+        job_id = None
+
+        with caplog.at_level(logging.INFO):
+            # When
+            resolved = resolve_job_id(
+                tasks_file=tasks_file,
+                memory_dir=memory_dir,
+                job_id=job_id,
+            )
+
+        # Then
+        assert resolved is not None
+        assert tasks_file.stem in resolved
+        assert "Starting" in caplog.text
+
+    @staticmethod
+    def test_id_passed(caplog: LogCaptureFixture):
+        # Given
+        tasks_file = Path("tasks/sample.py")
+        memory_dir = Path("memory")
+        job_id = "foo-123"
+
+        with caplog.at_level(logging.INFO):
+            # When
+            resolved = resolve_job_id(
+                tasks_file=tasks_file,
+                memory_dir=memory_dir,
+                job_id=job_id,
+            )
+
+        # Then
+        assert resolved == job_id
+        assert "Resuming" in caplog.text
 
 
 class TestFindTasksInModule:

--- a/tests/unit/dsl/test_dsl.py
+++ b/tests/unit/dsl/test_dsl.py
@@ -74,7 +74,7 @@ class TestResolveJobID:
 
         # Then
         assert resolved == "foo-123"
-        assert "Resuming" in caplog.text
+        assert "Resuming job foo-123" in caplog.text
 
 
 class TestFindTasksInModule:

--- a/tests/unit/dsl/test_dsl.py
+++ b/tests/unit/dsl/test_dsl.py
@@ -1,3 +1,5 @@
+import shutil
+import sys
 from pathlib import Path
 from pytest import MonkeyPatch, fixture
 from freezegun import freeze_time
@@ -5,8 +7,29 @@ from slfl._dsl import (
     find_tasks_in_module,
     get_memory_dir,
     gen_job_id,
+    load_module_file,
 )
 from ...example_proj.sample import tasks as sample_tasks
+
+
+class TestLoadModuleFile:
+    @staticmethod
+    def test_sample_file(tmp_path: Path):
+        # Given
+        starting_sys_path = list(sys.path)
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+
+        tasks_file = tasks_dir / "tasks_file.py"
+        shutil.copy(sample_tasks.__file__, tasks_file)
+
+        # When
+        module = load_module_file(tasks_file)
+
+        # Then
+        assert module is not None
+        assert "amount_transfered_to_main" in dir(module)
+        assert sys.path == starting_sys_path, "Shouldn't alter global sys.path"
 
 
 class TestFindTasksInModule:

--- a/tests/unit/dsl/test_dsl.py
+++ b/tests/unit/dsl/test_dsl.py
@@ -42,14 +42,14 @@ class TestResolveJobID:
         # Given
         tasks_file = Path("tasks/sample.py")
         memory_dir = Path("memory")
-        job_id = None
+        memory_file = None
 
         with caplog.at_level(logging.INFO):
             # When
             resolved = resolve_job_id(
                 tasks_file=tasks_file,
                 memory_dir=memory_dir,
-                job_id=job_id,
+                memory_file=memory_file,
             )
 
         # Then
@@ -62,18 +62,18 @@ class TestResolveJobID:
         # Given
         tasks_file = Path("tasks/sample.py")
         memory_dir = Path("memory")
-        job_id = "foo-123"
+        memory_file = Path("memory/foo-123.yaml")
 
         with caplog.at_level(logging.INFO):
             # When
             resolved = resolve_job_id(
                 tasks_file=tasks_file,
                 memory_dir=memory_dir,
-                job_id=job_id,
+                memory_file=memory_file,
             )
 
         # Then
-        assert resolved == job_id
+        assert resolved == "foo-123"
         assert "Resuming" in caplog.text
 
 


### PR DESCRIPTION
Before:
```bash
slfl path/to/tasks.py -j 1234-job-id
```


After:
```bash
slfl path/to/tasks.py -m memory/1234-job-id.yaml
```

This change lets us piggyback on a standard file path tab completion.
